### PR TITLE
Removed version requirements on pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
                       "enum-compat",
                       "futures; python_version == '2.7'",
                       "mockextras",
-                      "pandas<=1.0.3",
+                      "pandas",
                       "pymongo>=3.6.0",
                       "python-dateutil",
                       "pytz",


### PR DESCRIPTION
Version restriction on pandas should no longer be required since the Panel issue has already been fixed in other commits.